### PR TITLE
Add the ability to view CSGOs player profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,45 @@ the data is already available in `inventory`.
 
 The response will arrive in the callback and in the `inspectItemInfo` event.
 
+### requestPlayersProfile(steamid[, callback])
+- `steamid` - The numeric SteamID of the Steam account to pull profile data for. Needs to be playing CSGO and be on the friend list of the requesting account.
+- `callback` - Optional. Called if all parameters are valid when Steam responds to us.
+    - `profile` - An object containing the profiledata
+        - `accountid` - Steam account id
+	- `ongoingmatch`
+	- `globalStats` - Seems to always be `null`
+	- `penaltySeconds`
+	- `penaltyReason`
+	- `vacBanned`
+	- `ranking`
+	    - `accountid`
+	    - `rankId` - Matchmaking rank (0-18), starting at 0 for unranked
+	    - `wins` - Number of matchmaking wins
+	    - `rankChange` - Seems to always be `null`
+	- `commendation`
+	    - `cmdFriendly` - The number of "friendly" commendations the account has received
+	    - `cmdTeaching` - The number of "teaching" commendations the account has received
+	    - `cmdLeader` - The number of "leader" commendations the account has received
+	- `medals` - Archievement medals, their ranks and coins
+	    - `medalTeam`
+	    - `medalCombat`
+	    - `medalWeapon`
+	    - `medalGlobal`
+	    - `medalArms`
+	    - `legacy_CoinOpPayback`
+	    - `displayedItemsDefidx` - Array of coins
+	    - `featuredDisplayItemDefidx`
+	- `myCurrentEvent`
+	- `myCurrentEventTeams`
+	- `myCurrentTeam`
+	- `myCurrentEventStages`
+	- `surveyVote`
+	- `activity`
+	- `secondsUntilNextMission`
+	
+Sends the same request to the GC that viewing the CSGO player profile from the in-game friendlist sends. Returns the same information that you would get in-game.
+This returns the same protobuf that is used when you request your own profile data, so most of it stays empty.
+	
 # Events
 
 ### connectedToGC
@@ -177,3 +216,39 @@ Emitted when an item in your inventory changes in some way.
 - `item` - The item that you lost
 
 Emitted when an item is removed from your inventory.
+
+### playersProfile
+- `profile` - An object containing the profiledata
+        - `accountid` - Steam account id
+	- `ongoingmatch`
+	- `globalStats` - Seems to always be `null`
+	- `penaltySeconds`
+	- `penaltyReason`
+	- `vacBanned`
+	- `ranking`
+	    - `accountid`
+	    - `rankId` - Matchmaking rank (0-18), starting at 0 for unranked
+	    - `wins` - Number of matchmaking wins
+	    - `rankChange` - Seems to always be `null`
+	- `commendation`
+	    - `cmdFriendly` - The number of "friendly" commendations the account has received
+	    - `cmdTeaching` - The number of "teaching" commendations the account has received
+	    - `cmdLeader` - The number of "leader" commendations the account has received
+	- `medals` - Archievement medals, their ranks and coins
+	    - `medalTeam`
+	    - `medalCombat`
+	    - `medalWeapon`
+	    - `medalGlobal`
+	    - `medalArms`
+	    - `legacy_CoinOpPayback`
+	    - `displayedItemsDefidx` - Array of coins
+	    - `featuredDisplayItemDefidx`
+	- `myCurrentEvent`
+	- `myCurrentEventTeams`
+	- `myCurrentTeam`
+	- `myCurrentEventStages`
+	- `surveyVote`
+	- `activity`
+	- `secondsUntilNextMission`
+
+Emitted in response to an `requestPlayersProfile()` call.

--- a/handlers.js
+++ b/handlers.js
@@ -3,6 +3,7 @@ var fs = require('fs');
 var GlobalOffensive = require('./index.js');
 var Language = require('./language.js');
 var Protos = require('./protos.js');
+var SteamID = require('steamid');
 
 var handlers = GlobalOffensive.prototype._handlers;
 
@@ -69,6 +70,22 @@ handlers[Language.MatchList] = function(body) {
 	var proto = Protos.CMsgGCCStrike15_v2_MatchList.decode(body);
 	this.emit('matchList', proto.matches, proto);
 };
+
+// PlayersProfile
+handlers[Language.PlayersProfile] = function (body) {
+  var proto = Protos.CMsgGCCStrike15_v2_PlayersProfile.decode(body);
+
+  if (!proto.accountProfiles[0]) {
+    return;
+  }
+
+  var profile = proto.accountProfiles[0];
+
+  var sid = SteamID.fromIndividualAccountID(profile.accountId);
+
+  this.emit('playersProfile', profile);
+  this.emit('playersProfile#' + sid.getSteamID64(), profile);
+}
 
 // Inspecting items
 handlers[Language.Client2GCEconPreviewDataBlockResponse] = function(body) {

--- a/index.js
+++ b/index.js
@@ -189,6 +189,10 @@ GlobalOffensive.prototype.inspectItem = function(owner, assetid, d, callback) {
 };
 
 GlobalOffensive.prototype.requestPlayersProfile = function (steamid, callback) {
+  if (typeof steamid === 'object') {
+    steamid = steamid.toString();
+  }
+
   var sid = new SteamID(steamid);
 
   if (!sid.isValid() || sid.universe != SteamID.Universe.PUBLIC || sid.type != SteamID.Type.INDIVIDUAL || sid.instance != SteamID.Instance.DESKTOP) {

--- a/index.js
+++ b/index.js
@@ -188,6 +188,23 @@ GlobalOffensive.prototype.inspectItem = function(owner, assetid, d, callback) {
 	}
 };
 
+GlobalOffensive.prototype.requestPlayersProfile = function (steamid, callback) {
+  var sid = new SteamID(steamid);
+
+  if (!sid.isValid() || sid.universe != SteamID.Universe.PUBLIC || sid.type != SteamID.Type.INDIVIDUAL || sid.instance != SteamID.Instance.DESKTOP) {
+    return false;
+  }
+
+  this._send(Language.ClientRequestPlayersProfile, Protos.CMsgGCCStrike15_v2_ClientRequestPlayersProfile, {
+    accountId: sid.accountid,
+    requestLevel: 32
+  });
+
+  if (callback) {
+    this.once('playersProfile#' + sid.getSteamID64(), callback);
+  }
+};
+
 GlobalOffensive.prototype._handlers = {};
 
 function coerceToLong(num, signed) {


### PR DESCRIPTION
Added `requestPlayersProfile(steamid[, callback)`
Added `playersProfile` event

I tried to match the existing code-style as well as I could.
If there are any changes you would like to see, please let me know.

I have tested this with multiple accounts and invalid data.

The documentation is still work-in-progress as I still need some tests to make sure my assumptions about several values are correct, but wanted to make sure that the code is in order first.