### PR TITLE
Fix incorrect name for steamid variable in requestLiveGameForUser

### DIFF
--- a/index.js
+++ b/index.js
@@ -177,7 +177,7 @@ GlobalOffensive.prototype.requestLiveGameForUser = function(steamid) {
 	}
 
 	this._send(Language.MatchListRequestLiveGameForUser, Protos.CMsgGCCStrike15_v2_MatchListRequestLiveGameForUser, {
-		accountid: sid.accountid
+		accountid: steamid.accountid
 	});
 };
 


### PR DESCRIPTION
There is an error inside the `requestLiveGameForUser` method, where the `steamid variable` is incorrenctly referenced as `sid`

Also, I have a question regarding the `requestRecentGames` function. It doesn't return anything, unless you specify your own steamID. Is that the way it should behave? I am looking for a way to get the Sharecode from a match after it has ended.
