### PR TITLE
added overwatch case handling

### DIFF
--- a/handlers.js
+++ b/handlers.js
@@ -76,6 +76,12 @@ handlers[Language.ClientConnectionStatus] = function(body) {
 	}
 };
 
+// Overwatch Assignment
+handlers[Language.PlayerOverwatchCaseAssignment] = function(body) {
+	let proto = decodeProto(Protos.CMsgGCCStrike15_v2_PlayerOverwatchCaseAssignment, body);
+	this.emit('overwatchAssignment', proto, proto);
+};
+
 // MatchList
 handlers[Language.MatchList] = function(body) {
 	let proto = decodeProto(Protos.CMsgGCCStrike15_v2_MatchList, body);

--- a/index.js
+++ b/index.js
@@ -150,6 +150,14 @@ GlobalOffensive.prototype._send = function(type, protobuf, body) {
 	return true;
 };
 
+GlobalOffensive.prototype.requestOverwatchCaseUpdate = function(caseupdate) {
+	this._send(Language.PlayerOverwatchCaseUpdate, Protos.CMsgGCCStrike15_v2_PlayerOverwatchCaseUpdate, caseupdate || { reason: 1 });
+};
+
+GlobalOffensive.prototype.sendOverwatchCaseStatus = function(caseid, statusid) {
+	this._send(Language.PlayerOverwatchCaseStatus, Protos.CMsgGCCStrike15_v2_PlayerOverwatchCaseStatus, { caseid: caseid, statusid: statusid });
+};
+
 GlobalOffensive.prototype.requestLiveGames = function() {
 	this._send(Language.MatchListRequestCurrentLiveGames, Protos.CMsgGCCStrike15_v2_MatchListRequestCurrentLiveGames, {});
 };


### PR DESCRIPTION
## Methods
`requestOverwatchCaseUpdate(caseupdate)`
* request a new overwatch case by sending `{ reason: 1 }`
* submit a verdict by sending a caseupdate object
```javascript
{
    caseid: assignment.caseid,
    suspectid: assignment.suspectid,
    fractionid: assignment.fractionid,
    rpt_aimbot: 0, // 0 = Not enough evidence
    rpt_wallhack: 1, // 1 = Evidence beyond a reasonable doubt
    rpt_speedhack: 0,
    rpt_teamharm: 0,
    reason: 3
}
```

`sendOverwatchCaseStatus(caseid, statusid)`
* send an overwatch status for a given caseid
  * for example to tell the GC that we finished the demo download (statusid: 1)

## Events
`overwatchAssignment`
* includes information about an overwatch case

```javascript
message CMsgGCCStrike15_v2_PlayerOverwatchCaseAssignment {
	optional uint64 caseid = 1; // will be empty if we are on cooldown
	optional string caseurl = 2; // will be empty if response comes from sending a verdict
	optional uint32 verdict = 3;
	optional uint32 timestamp = 4;
	optional uint32 throttleseconds = 5;
	optional uint32 suspectid = 6;
	optional uint32 fractionid = 7;
	optional uint32 numrounds = 8;
	optional uint32 fractionrounds = 9;
	optional int32 streakconvictions = 10;
	optional uint32 reason = 11;
}
```