### PR TITLE
Parse charm details in inventory array

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ related events), where applicable:
     - `offset_y` - Float, `null` if not applicable
 - `casket_id` - If this item is contained in a casket (storage unit), this is a string containing that casket's item ID
 - `casket_contained_item_count` - If this item is a casket (storage unit), this is a count of how many items it contains
+- `charm` - If a charm (sometimes referred to as keychain) is attached to the item, this object contains details about the charm.
+    - `charm_id` - The ID of the charm
+    - `offset_x` - Float
+    - `offset_y` - Float
+    - `offset_z` - Float
+    - `pattern` - The charm's pattern (1-100,000)
 
 Note that if any of the above attributes are not applicable, then they will not exist in the item object.
 

--- a/handlers.js
+++ b/handlers.js
@@ -249,6 +249,23 @@ GlobalOffensive.prototype._processSOEconItem = function(item) {
 		item.stickers = stickers;
 	}
 
+	// charms
+	let charmIdBytes = getAttributeValueBytes(299);
+	let charmOffsetXBytes = getAttributeValueBytes(300);
+	let charmOffsetYBytes = getAttributeValueBytes(301);
+	let charmOffsetZBytes = getAttributeValueBytes(302);
+	let charmPatternBytes = getAttributeValueBytes(306);
+
+	if (charmIdBytes && charmOffsetXBytes && charmOffsetYBytes && charmOffsetZBytes && charmPatternBytes) {
+		item.charm = {
+			charm_id: charmIdBytes.readUInt32LE(0),
+			offset_x: charmOffsetXBytes.readFloatLE(0),
+			offset_y: charmOffsetYBytes.readFloatLE(0),
+			offset_z: charmOffsetZBytes.readFloatLE(0),
+			pattern: charmPatternBytes.readUInt32LE(0),
+		};
+	}
+
 	// def_index-specific attribute parsing
 	switch (item.def_index) {
 		case 1201:


### PR DESCRIPTION
#98 added charm support to item inspection, however, there is currently no support for charms on items in the own inventory/storage units.

This PR adds charm detail parsing so the item objects are populated with a new `charm` property:

- `charm` - If a charm (sometimes referred to as keychain) is attached to the item, this object contains details about the charm.
    - `charm_id` - The ID of the charm
    - `offset_x` - Float
    - `offset_y` - Float
    - `offset_z` - Float
    - `pattern` - The charm's pattern (1-100,000)

The naming i chose is not consistent with the names in the `inspectItem` result, however as this is the case for most of the keys, i decided to go with `charm` for clarity.
Let me know if you think we should go with a different naming scheme.

In the `inspectItem` result, an array is provided as it seems like there is technical support for multiple charms (possibly because the logic is copied from stickers). As of now, only a single charm is allowed so i decided against using an array of lenght one. If you think we should go with the array solution for possible future compatability, let me know.